### PR TITLE
VP-2753: Use asp.net 3.1 base image

### DIFF
--- a/linux/storefront/Dockerfile
+++ b/linux/storefront/Dockerfile
@@ -1,6 +1,6 @@
 	# escape=`
 # Build runtime image
-FROM microsoft/dotnet:2.2-aspnetcore-runtime
+FROM mcr.microsoft.com/dotnet/core/aspnet:3.1
 
 # Install unzip
 #RUN apt-get update && apt-get install -y unzip


### PR DESCRIPTION
### Problem
Storefront V3 cannot start because of .net 3.1 is not available

### Solution
Change base image

### Proposed of changes
Change base image

### Additional context (optional)
 N/A