### PR TITLE
Vcst: 1753

### DIFF
--- a/linux/platform/Dockerfile
+++ b/linux/platform/Dockerfile
@@ -16,13 +16,11 @@ COPY publish /opt/virtocommerce/platform
 
 COPY ./wait-for-it.sh /wait-for-it.sh
 RUN chmod +x wait-for-it.sh
-RUN apt-get update && apt-get install -y wget fontconfig libfreetype6 libx11-6 libxcb1 libxext6 libxrender1 xfonts-75dpi xfonts-base libjpeg62-turbo \
-  && wget http://http.us.debian.org/debian/pool/main/o/openssl/libssl3_3.0.14-1~deb12u1_amd64.deb \
-  && dpkg -i libssl3_3.0.14-1~deb12u1_amd64.deb \
+RUN apt-get update && apt-get install -y wget fontconfig libfreetype6 libx11-6 libxcb1 libxext6 libxrender1 xfonts-75dpi xfonts-base libjpeg62-turbo libssl3=3.0.* \
   && wget https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-3/wkhtmltox_0.12.6.1-3.bookworm_amd64.deb \
   && dpkg -i wkhtmltox_0.12.6.1-3.bookworm_amd64.deb
 
 WORKDIR /opt/virtocommerce/platform
 EXPOSE 80
 ENV ASPNETCORE_HTTP_PORTS=80
-ENTRYPOINT ["dotnet", "VirtoCommerce.Platform.Web.dll"]  
+ENTRYPOINT ["dotnet", "VirtoCommerce.Platform.Web.dll"]


### PR DESCRIPTION
Replace the libssl3 installation step using the concrete version with the package manager installation of the minor version.